### PR TITLE
Fix Exception when the job itself has failed.

### DIFF
--- a/src/main/resources/templates/slack-incoming-message.ftl
+++ b/src/main/resources/templates/slack-incoming-message.ftl
@@ -35,8 +35,8 @@
             }
 <#if trigger == "failure">
             ,{
-               "title":"Faild Nodes",
-               "value":"${executionData.failedNodeListString}",
+               "title":"Failed Nodes",
+               "value":"${executionData.failedNodeListString!"- (Job itself failed)"}",
                "short":false
             }
 </#if>


### PR DESCRIPTION
A Rundeck job can fail before any nodes have failed.
This causes an exception:

```
> Caused by: freemarker.core.InvalidReferenceException: The following has evaluated to null or missing:
> ==> executionData.failedNodeListString  [in template "slack-incoming-message.ftl" at line 39, column 27]
>
> Tip: If the failing expression is known to be legally null/missing, either specify a default value with myOptionalVar!myDefault, or use <#if myOptionalVar??>when-present<#else>when-missing</#if>. (These only cover the last step of the expression; to cover the whole expression, use parenthessis:
> (myOptionVar.foo)!myDefault, (myOptionVar.foo)??
>
> The failing instruction:
> ==> ${executionData.failedNodeListString}  [in template "slack-incoming-message.ftl" at line 39, column 25]
>   at freemarker.core.InvalidReferenceException.getInstance(InvalidReferenceException.java:98)
> ...
```

This prevents the notification from being sent, so print a default message
instead.
