### PR TITLE
Separate Templates for Rundeck jobs when `Started`, `Success` and `Failure`

### DIFF
--- a/src/main/java/com/bitplaces/rundeck/plugins/slack/SlackNotificationPlugin.java
+++ b/src/main/java/com/bitplaces/rundeck/plugins/slack/SlackNotificationPlugin.java
@@ -53,7 +53,9 @@ public class SlackNotificationPlugin implements NotificationPlugin {
 
     private static final String SLACK_MESSAGE_FROM_NAME = "Rundeck";
 //    private static final String SLACK_EXT_MESSAGE_TEMPLATE_PATH = "/var/lib/rundeck/libext/templates";
-    private static final String SLACK_MESSAGE_TEMPLATE = "slack-incoming-message.ftl";
+    private static final String SLACK_MESSAGE_TEMPLATE_SUCCESS = "slack-template-success.ftl";
+    private static final String SLACK_MESSAGE_TEMPLATE_FAILED = "slack-template-error.ftl";
+    private static final String SLACK_MESSAGE_TEMPLATE_STARTED = "slack-template-started.ftl";
 
     private static final String TRIGGER_START = "start";
     private static final String TRIGGER_SUCCESS = "success";
@@ -96,12 +98,12 @@ public class SlackNotificationPlugin implements NotificationPlugin {
             TemplateLoader[] loaders = new TemplateLoader[]{builtInTemplate};
             MultiTemplateLoader mtl = new MultiTemplateLoader(loaders);
             FREEMARKER_CFG.setTemplateLoader(mtl);
-            ACTUAL_SLACK_TEMPLATE = SLACK_MESSAGE_TEMPLATE;
+            //ACTUAL_SLACK_TEMPLATE = SLACK_MESSAGE_TEMPLATE;
 //        }
 
-        TRIGGER_NOTIFICATION_DATA.put(TRIGGER_START,   new SlackNotificationData(ACTUAL_SLACK_TEMPLATE, SLACK_MESSAGE_COLOR_YELLOW));
-        TRIGGER_NOTIFICATION_DATA.put(TRIGGER_SUCCESS, new SlackNotificationData(ACTUAL_SLACK_TEMPLATE, SLACK_MESSAGE_COLOR_GREEN));
-        TRIGGER_NOTIFICATION_DATA.put(TRIGGER_FAILURE, new SlackNotificationData(ACTUAL_SLACK_TEMPLATE, SLACK_MESSAGE_COLOR_RED));
+        TRIGGER_NOTIFICATION_DATA.put(TRIGGER_START,   new SlackNotificationData(SLACK_MESSAGE_TEMPLATE_STARTED, SLACK_MESSAGE_COLOR_YELLOW));
+        TRIGGER_NOTIFICATION_DATA.put(TRIGGER_SUCCESS, new SlackNotificationData(SLACK_MESSAGE_TEMPLATE_SUCCESS, SLACK_MESSAGE_COLOR_GREEN));
+        TRIGGER_NOTIFICATION_DATA.put(TRIGGER_FAILURE, new SlackNotificationData(SLACK_MESSAGE_TEMPLATE_FAILED, SLACK_MESSAGE_COLOR_RED));
 
         try {
             FREEMARKER_CFG.setSetting(Configuration.CACHE_STORAGE_KEY, "strong:20, soft:250");

--- a/src/main/resources/templates/slack-template-error.ftl
+++ b/src/main/resources/templates/slack-template-error.ftl
@@ -1,0 +1,66 @@
+<#if executionData.job.group??>
+    <#assign jobName="${executionData.job.group} / ${executionData.job.name}">
+<#else>
+    <#assign jobName="${executionData.job.name}">
+</#if>
+<#assign message="FAILED! Job <${executionData.href}|#${executionData.id}  ${jobName}>">
+<#assign state="Failed">
+
+<#if executionData.argstring??>
+    <#assign args="${executionData.argstring}">
+<#else>
+    <#assign args="No options to display">
+</#if>
+
+
+<#if executionData.succeededNodeListString??>
+    <#assign successNodes="${executionData.succeededNodeListString}">
+<#else>
+    <#assign successNodes="None">
+</#if>
+
+{
+   "attachments":[
+      {
+         "fallback":"${state}: ${message}",
+         "pretext":"${message}",
+         "color":"${color}",
+         "fields":[
+            {
+               "title":"Job Name",
+               "value":"<${executionData.job.href}|${jobName}>",
+               "short":false
+            },
+            {
+		"title": "Job Completed at",
+		"value": "${executionData.dateEndedW3c}",
+		"short": true
+	    },
+	    {	"title": "Project",
+		"value": "${executionData.project}",
+		"short": true
+	    }, 
+            {
+               "title":"Started By",
+               "value":"${executionData.user}",
+               "short":true
+	    },
+            {
+               "title":"Options",
+               "value":"${args}",
+               "short":false
+            },
+	    {
+               "title":"Failed On",
+               "value":"${executionData.failedNodeListString}",
+               "short":false
+            },
+	    {
+		"title": "Successful On",
+		"value": "${successNodes}",
+		"short": false
+	    }
+	]
+      }
+   ]
+}

--- a/src/main/resources/templates/slack-template-started.ftl
+++ b/src/main/resources/templates/slack-template-started.ftl
@@ -1,0 +1,44 @@
+<#if executionData.job.group??>
+    <#assign jobName="${executionData.job.group} / ${executionData.job.name}">
+<#else>
+    <#assign jobName="${executionData.job.name}">
+</#if>
+<#assign message="STARTED Job <${executionData.href}|#${executionData.id} ${jobName}>">
+<#assign state="Started">
+
+{
+   "attachments":[
+      {
+         "fallback":"${state}: ${message}",
+         "pretext":"${message}",
+         "color":"${color}",
+         "fields":[
+            {
+               "title":"Job Name",
+               "value":"<${executionData.job.href}|${jobName}>",
+               "short":false
+            },
+            {
+               "title":"Project",
+               "value":"${executionData.project}",
+               "short":true
+            },
+            {
+               "title":"Started By",
+               "value":"${executionData.user}",
+               "short":true
+            },
+            {
+		"title": "Job Start Time",
+		"value": "${executionData.dateStartedW3c}",
+		"short": true
+	    },
+	    {
+		"title": "Job Status",
+		"value": "Started",
+		"short": true
+	    }
+	]
+      }
+   ]
+}

--- a/src/main/resources/templates/slack-template-success.ftl
+++ b/src/main/resources/templates/slack-template-success.ftl
@@ -1,0 +1,56 @@
+<#if executionData.job.group??>
+    <#assign jobName="${executionData.job.group} / ${executionData.job.name}">
+<#else>
+    <#assign jobName="${executionData.job.name}">
+</#if>
+<#assign message="SUCCESS Job <${executionData.href}|#${executionData.id}  ${jobName}>">
+
+<#if executionData.argstring??>
+    <#assign args="${executionData.argstring}">
+<#else>
+    <#assign args="No arguments to display">
+</#if>
+
+<#assign state="Succeeded">
+
+{
+   "attachments":[
+      {
+         "fallback":"${state}: ${message}",
+         "pretext":"${message}",
+         "color":"${color}",
+         "fields":[
+            {
+               "title":"Job Name",
+               "value":"<${executionData.job.href}|${jobName}>",
+               "short":false
+            },
+	    {
+		"title": "Job Completed At",
+		"value": "${executionData.dateEndedW3c}",
+		"short": true 
+	    },
+            {
+               "title":"Project",
+               "value":"${executionData.project}",
+               "short":true
+            },
+            {
+               "title":"Started By",
+               "value":"${executionData.user}",
+               "short":true
+            },
+            {
+               "title":"Options",
+               "value":"${args}",
+               "short":false
+            },
+	    {
+		"title": "Nodes affected",
+		"value": "${executionData.succeededNodeListString}",
+		"short": false
+	    }
+	]
+      }
+   ]
+}


### PR DESCRIPTION
Separate templates are created to accommodate the changes based on the status of the rundeck job. 

Objective of the separation was to help reduce the complexity in editing the files based on status.