### PR TITLE
Update to the templates to include the start time of the job.

### DIFF
--- a/src/main/resources/templates/slack-template-error.ftl
+++ b/src/main/resources/templates/slack-template-error.ftl
@@ -31,8 +31,13 @@
                "value":"<${executionData.job.href}|${jobName}>",
                "short":false
             },
+	    {
+		"title": "Job Start Time",
+		"value": "${executionData.dateStartedW3c}",
+		"short": true
+	    },
             {
-		"title": "Job Completed at",
+		"title": "Job End Time",
 		"value": "${executionData.dateEndedW3c}",
 		"short": true
 	    },

--- a/src/main/resources/templates/slack-template-success.ftl
+++ b/src/main/resources/templates/slack-template-success.ftl
@@ -26,7 +26,12 @@
                "short":false
             },
 	    {
-		"title": "Job Completed At",
+		"title": "Job Start Time",
+		"value": "${executionData.dateStartedW3c}",
+		"short": true
+	    },
+	    {
+		"title": "Job End Time",
 		"value": "${executionData.dateEndedW3c}",
 		"short": true 
 	    },


### PR DESCRIPTION
The Success and Error templates are edited to add the Start time of the job to let the user know in summary when the job was started and ended in one single message. It is useful especially for long running jobs.