### PR TITLE
add override itemes on slack

### DIFF
--- a/src/main/java/com/bitplaces/rundeck/plugins/slack/SlackNotificationPlugin.java
+++ b/src/main/java/com/bitplaces/rundeck/plugins/slack/SlackNotificationPlugin.java
@@ -85,10 +85,34 @@ public class SlackNotificationPlugin implements NotificationPlugin {
     private String webhook_url_override;
 
     @PluginProperty(
-        title = "Notification template",
-        description = "Custom notification template, if not supplied the defaults will be used",
-        scope = PropertyScope.InstanceOnly,
-        required = false
+            title = "Notification channel Override",
+            description = "Notification channel",
+            scope = PropertyScope.InstanceOnly,
+            required = false
+    )
+    private String slack_channel_override;
+
+    @PluginProperty(
+            title = "Notification username Override",
+            description = "Notification username",
+            scope = PropertyScope.InstanceOnly,
+            required = false
+    )
+    private String slack_username_override;
+
+    @PluginProperty(
+            title = "Notification icon Override",
+            description = "Notification icon",
+            scope = PropertyScope.InstanceOnly,
+            required = false
+    )
+    private String slack_icon_override;
+
+    @PluginProperty(
+            title = "Notification template",
+            description = "Custom notification template, if not supplied the defaults will be used",
+            scope = PropertyScope.InstanceOnly,
+            required = false
     )
     private String slack_template;
 
@@ -222,6 +246,10 @@ public class SlackNotificationPlugin implements NotificationPlugin {
         model.put("color", color);
         model.put("executionData", executionData);
         model.put("config", config);
+        model.put("channel_override", this.slack_channel_override);
+        model.put("username_override", this.slack_username_override);
+        model.put("icon_override", this.slack_icon_override);
+
         final StringWriter writer = new StringWriter();
         try {
             Template ftl = SlackNotificationPlugin.FREEMARKER_CFG.getTemplate(template);

--- a/src/main/resources/templates/slack-template-error.ftl
+++ b/src/main/resources/templates/slack-template-error.ftl
@@ -20,6 +20,15 @@
 </#if>
 
 {
+<#if channel_override?has_content >
+    "channel":"${channel_override}",
+</#if>
+<#if username_override?has_content >
+    "username": "${username_override}",
+</#if>
+<#if icon_override?has_content >
+    "icon_emoji":"${icon_override}",
+</#if>
    "attachments":[
       {
          "fallback":"${state}: ${message}",

--- a/src/main/resources/templates/slack-template-started.ftl
+++ b/src/main/resources/templates/slack-template-started.ftl
@@ -7,6 +7,15 @@
 <#assign state="Started">
 
 {
+<#if channel_override?has_content >
+    "channel":"${channel_override}",
+</#if>
+<#if username_override?has_content >
+    "username": "${username_override}",
+</#if>
+<#if icon_override?has_content >
+    "icon_emoji":"${icon_override}",
+</#if>
    "attachments":[
       {
          "fallback":"${state}: ${message}",

--- a/src/main/resources/templates/slack-template-success.ftl
+++ b/src/main/resources/templates/slack-template-success.ftl
@@ -14,6 +14,15 @@
 <#assign state="Succeeded">
 
 {
+<#if channel_override?has_content >
+   "channel":"${channel_override}",
+</#if>
+<#if username_override?has_content >
+   "username": "${username_override}",
+</#if>
+<#if icon_override?has_content >
+   "icon_emoji":"${icon_override}",
+</#if>
    "attachments":[
       {
          "fallback":"${state}: ${message}",


### PR DESCRIPTION
This pull request  add the following items.

- channel
- username
- icon

![image](https://user-images.githubusercontent.com/1995330/54417054-6dfa9e00-4744-11e9-82a6-d011bd063360.png)

If it is blank, it is used default setteing.